### PR TITLE
Yay JS Tooling!!!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 node_modules/
 npm-debug.log
-
+build/

--- a/index.jsx
+++ b/index.jsx
@@ -7,7 +7,7 @@ var Person = function() {  // kind of like a Class
     var job = 'Male model';
     return (
         <div className="person">
-            <div className="person-name">{name}</div>  // kind of like #{var}
+            <div className="person-name">{name}</div>  // kind of like {"{var}"}
             <img className="person-img" src={imageUrl} />
             <div className="person-job">
                 {job}

--- a/package.json
+++ b/package.json
@@ -2,17 +2,20 @@
   "name": "lesson_1",
   "version": "1.0.0",
   "description": "pairing with aric and nicolas",
-  "main": "webpack.config.js",
+  "main": "index.jsx",
   "dependencies": {
+    
+    "react": "^15.2.0",
+    "react-dom": "^15.2.0"
+    
+  },
+  "devDependencies": {
+    "webpack": "^1.13.1",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
-    "babel-preset-react": "^6.11.1",
-    "react": "^15.2.0",
-    "react-dom": "^15.2.0",
-    "webpack": "^1.13.1"
+    "babel-preset-react": "^6.11.1"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
adjusted package.json to move dev dependencies into dev dependencies space. They don't need to be installed when it's deployed, so they go into a different cat. Also, changed the entry point from webpack.config.js to index.jsx. It was failing because webpack knows to ignore it's own config file, but trying to pack itself makes a death spiral. Once that worked, the comment in the jsx file was breaking the build because of the #{var}. Apparently, the # is bad (dunno why) and the {var} was looking for a variable. Wrapping it in another set of braces and putting it in quotes tells the compiler not to eval that as a variable.
